### PR TITLE
Add GitHub Actions workflow for running pytest suite

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,0 +1,53 @@
+name: Python Tests
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'src/**'
+      - 'tests/**'
+      - 'pyproject.toml'
+      - '.github/workflows/pytest.yml'
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'src/**'
+      - 'tests/**'
+      - 'pyproject.toml'
+      - '.github/workflows/pytest.yml'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.10', '3.11', '3.12']
+
+    steps:
+    - uses: actions/checkout@v3
+    
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+        cache: 'pip'
+    
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install .[dev,ai]
+    
+    - name: Setup git
+      run: |
+        git config --global user.email "test@example.com"
+        git config --global user.name "Test User"
+    
+    - name: Run tests with pytest
+      run: |
+        pytest tests/python/ -v --cov=src/py_opencommit --cov-report=xml
+    
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v3
+      with:
+        file: ./coverage.xml
+        fail_ci_if_error: false

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -2,14 +2,14 @@ name: Python Tests
 
 on:
   push:
-    branches: [ main ]
+    branches: [ master ]
     paths:
       - 'src/**'
       - 'tests/**'
       - 'pyproject.toml'
       - '.github/workflows/pytest.yml'
   pull_request:
-    branches: [ main ]
+    branches: [ master ]
     paths:
       - 'src/**'
       - 'tests/**'


### PR DESCRIPTION
This PR adds a GitHub Actions workflow for running the pytest suite on Python 3.10, 3.11, and 3.12.

## Changes

- Added `.github/workflows/pytest.yml` to run tests on push and pull requests
- Configured workflow to run on Python 3.10, 3.11, and 3.12
- Set up test coverage reporting with Codecov
- Fixed test_hook_script_handles_merge_commit for Python 3.12 compatibility by replacing the use of exec() with a more direct approach

The workflow will run whenever changes are made to the source code, tests, or configuration files.